### PR TITLE
Fix tooltip applying to spinner buttons

### DIFF
--- a/src/gui_window_font_atlas.h
+++ b/src/gui_window_font_atlas.h
@@ -385,9 +385,10 @@ void GuiWindowFontAtlas(GuiWindowFontAtlasState *state)
         state->btnSaveFontAtlasPressed = GuiButton((Rectangle){ state->anchor.x + 12 + 28 + 28, state->anchor.y + 32, 24, 24 }, "#12#");
 
         if (!FileExists(inFontFileName)) GuiDisable();
+        GuiDisableTooltip();
         prevFontGenSizeValue = state->fontGenSizeValue;
         if (GuiSpinner((Rectangle){ state->anchor.x + 164, state->anchor.y + 32, 96, 24 }, "Gen Size: ", &state->fontGenSizeValue, 0, 100, state->fontGenSizeEditMode)) state->fontGenSizeEditMode = !state->fontGenSizeEditMode;
-        
+        GuiEnableTooltip();
         //GuiSetTooltip("Regenerate font atlas");
         //if (GuiButton((Rectangle){ state->anchor.x + 210, state->anchor.y + 32, 80, 24 }, "#142#Regen")) state->fontAtlasRegen = true;
         GuiEnable();


### PR DESCRIPTION
Currently the tooltip from the previous button carries over to the font size spinner buttons.
![image](https://github.com/raysan5/rguistyler/assets/52535319/8d7f30b2-bac9-405f-a232-45005a12250e)

The fix simply disables tooltips and enables after the spinner element
![image](https://github.com/raysan5/rguistyler/assets/52535319/b0ef423e-c845-42c0-bcca-3ee07caf83c9)

The behavior matches the font size spinner in the main control panel, which has no tooltips.
